### PR TITLE
Support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ dist: xenial
 sudo: required
 
 env:
+  - DJANGO_VERSION=1.11
   - DJANGO_VERSION=1.10
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 skipsdist = True
 envlist =
-    {py37,py36,py35,py27}-{django1.10,django1.9,django1.8}
+    {py37,py36,py35,py27}-{django1.11,django1.10,django1.9,django1.8}
     docs
 
 [testenv]
 changedir = {toxinidir}/tests
 deps =
+    django1.11: Django>=1.11,<2.0
     django1.10: Django>=1.10,<1.11
     django1.9: Django>=1.9,<1.10
     django1.8: Django>=1.8,<1.9


### PR DESCRIPTION
Supported Django versions: 1.8, 1.9, 1.10, 1.11
Travis CI Python versions: 3.5, 3.6, 3.7